### PR TITLE
Add paste functionality to FileDrop in Chrome

### DIFF
--- a/demo/tests.html
+++ b/demo/tests.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <h2>FileDrop Test Sheet</h2>
-    <p>This page tests <a href="http://filedropjs.org">FileDrop</a> global utility methods. If this page backgruond is green then everything went fine for you.</p>
+    <p>This page tests <a href="http://filedropjs.org">FileDrop</a> global utility methods. If this page background is green then everything went fine for you.</p>
 
     <p><b>Tested browsers that pass:</b></p>
     <ul>

--- a/filedrop.js
+++ b/filedrop.js
@@ -1561,12 +1561,13 @@
           types = e.clipboardData.types;
 
       Array.each(types, function(type, i) {
-        if (type.match(matchType) || e.clipboardData.items[i].type.match(matchType)) {
-          var blob = e.clipboardData.items[i].getAsFile();
+        var items = e.clipboardData.items || [];
+        if (type.match(matchType) || items[i].type.match(matchType)) {
+          var blob = items[i].getAsFile();
           var mime = blob.type.replace('image/', '');
           blob.name = 'Pasted-From-Clipboard.' + mime;
           file = new global.File(blob);
-          file.setNativeEntry(e.clipboardData.items[i])
+          file.setNativeEntry(items[i])
           global.callAllOfObject(self, 'fileSetup', file)
           if (file.size > 0 || file.nativeEntry) {
              files.push(file);

--- a/filedrop.js
+++ b/filedrop.js
@@ -790,11 +790,6 @@
       dragEnd: [],
       dragExit: [],
 
-      //
-      // function (eventObject)
-      paste: [],
-
-
       // Occurs when a file has been dropped on the zone element or when a file
       // was selected in/dropped onto fallback <form> to trigger <iframe> upload.
       // The former occurs in Firefox and Chrome-based browsers that support
@@ -924,6 +919,8 @@
       global.isIE9 || self.delegate(zoneNode, 'drop', 'upload')
     }
 
+    // Attaches a `onpaste` listener to the drop zone that then fires the
+    // upload event.
     self.hookPaste = function (zoneNode) {
       self.delegate(zoneNode, 'paste', 'upload')
     }

--- a/filedrop.js
+++ b/filedrop.js
@@ -1998,7 +1998,9 @@
       if (!self.size) {
         // Zero size also indicates that it might be a directory.
         global.hasConsole && console.warn('Trying to send an empty FileDrop.File.')
-      } else if (window.FileReader) {
+        // FileReader crashes Chrome for large files. Only use FileReader for
+        // files less than 10MB
+      } else if (self.size < 10000000 && window.FileReader) {
         // Using Firefox FileAPI.
         var reader = new FileReader
 

--- a/filedrop.js
+++ b/filedrop.js
@@ -1567,8 +1567,8 @@
           var mime = blob.type.replace('image/', '');
           blob.name = 'Pasted-From-Clipboard.' + mime;
           file = new global.File(blob);
-          file.setNativeEntry(items[i])
-          global.callAllOfObject(self, 'fileSetup', file)
+          file.setNativeEntry(items[i]);
+          global.callAllOfObject(self, 'fileSetup', file);
           if (file.size > 0 || file.nativeEntry) {
              files.push(file);
           }

--- a/filedrop.js
+++ b/filedrop.js
@@ -2037,8 +2037,8 @@
         // Zero size also indicates that it might be a directory.
         global.hasConsole && console.warn('Trying to send an empty FileDrop.File.')
         // FileReader crashes Chrome for large files. Only use FileReader for
-        // files less than 10MB
-      } else if (self.size < 10000000 && window.FileReader) {
+        // files less than 50MB
+      } else if (self.size < 50000000 && window.FileReader) {
         // Using Firefox FileAPI.
         var reader = new FileReader
 


### PR DESCRIPTION
This pull attaches a `paste` event to all FileDrop initialized zones which allows you to upload images straight from the clipboard.

So far I've only got this working in Chrome because Firefox handles Images in the clipboard in a totally different way.  Still working on the Firefox implementation.
